### PR TITLE
古いURLが404を返却するので新URLを適用した

### DIFF
--- a/bin/compile
+++ b/bin/compile
@@ -4,7 +4,7 @@ BUILD_DIR=$1
 CACHE_DIR=$2
 
 FONT_ZIP=IPAfont00303.zip
-FONTS_URL=https://ipafont.ipa.go.jp/old/ipafont/IPAfont00303.php
+FONTS_URL=https://ipafont.ipa.go.jp/IPAfont/IPAfont00303.zip
 FONTS=IPAfont00303
 
 [ -f $CACHE_DIR/$FONT_ZIP ] || \


### PR DESCRIPTION
## 参照
https://ipafont.ipa.go.jp/old/ipafont/download.html
