### PR TITLE
update font url

### DIFF
--- a/bin/compile
+++ b/bin/compile
@@ -4,7 +4,7 @@ BUILD_DIR=$1
 CACHE_DIR=$2
 
 FONT_ZIP=IPAfont00303.zip
-FONTS_URL=https://ipafont.ipa.go.jp/IPAfont/IPAfont00303.zip
+FONTS_URL=https://moji.or.jp/wp-content/ipafont/IPAfont/IPAfont00303.zip
 FONTS=IPAfont00303
 
 [ -f $CACHE_DIR/$FONT_ZIP ] || \


### PR DESCRIPTION
IPAFonts had been moved from [here](https://ipafont.ipa.go.jp/IPAfont/IPAfont00303.zip) and it returns HTTP 404 (so all builds failed).
I fixed URL and checked that it works well on my local env 🤗 